### PR TITLE
Implement global and per session rate limiting

### DIFF
--- a/protocol_listener.go
+++ b/protocol_listener.go
@@ -130,7 +130,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 					continue
 				}
 
-				ses := newSession()
+				ses := newSession(sessionLimiter, globalLimiter)
 
 				go ses.Serve()
 


### PR DESCRIPTION
Not actually tested :D

The global and session specific limits apply in parallel - the slower one will limit the actual rate. So it makes sense to for example set a 2 MB/s global limit and a 500 KB/s per session limit. When there are four sessions each running at 500 KB/s they will all start running into the global limit when a fifth joins the relay.

Limits apply to all sent data - so both directions in a given session share the same session limiter, as we resend all data.
