### PR TITLE
Server should respond to ping

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -161,6 +161,15 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 				}
 				conn.Close()
 
+			case protocol.Ping:
+				if err := protocol.WriteMessage(conn, protocol.Pong{}); err != nil {
+					if debug {
+						log.Println("Error writing pong:", err)
+					}
+					conn.Close()
+					continue
+				}
+
 			case protocol.Pong:
 				// Nothing
 


### PR DESCRIPTION
The client package can use this to keep a constantly updated latency figure, so we don't need to to connect tests every time we are interested in the latency.
