### PR TITLE
Add SucessExitStatus=2

### DIFF
--- a/etc/linux-systemd/syncthing-relaysrv.service
+++ b/etc/linux-systemd/syncthing-relaysrv.service
@@ -8,6 +8,7 @@ Group=syncthing-relaysrv
 ExecStart=/usr/bin/relaysrv
 WorkingDirectory=/var/lib/syncthing-relaysrv
 RootDirectory=/var/lib/syncthing-relaysrv
+SuccessExitStatus=2
 
 PrivateTmp=true
 ProtectSystem=full


### PR DESCRIPTION
sorry audrius for that spam today... :)

relaysrv returns 2 (maybe the go runtime?) when it is restarted by systemd.
Let's add that exit code to prevent the following error:

Oct 10 15:56:16 coruscant systemd[1]: syncthing-relaysrv.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Oct 10 15:56:16 coruscant systemd[1]: Stopped Syncthing relay server.
Oct 10 15:56:16 coruscant systemd[1]: syncthing-relaysrv.service: Unit entered failed state.
Oct 10 15:56:16 coruscant systemd[1]: syncthing-relaysrv.service: Failed with result 'exit-code'.
Oct 10 15:56:16 coruscant systemd[1]: Started Syncthing relay server.
