### PR TITLE
[wip] send more info to pool

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,12 +113,14 @@ func main() {
 	if globalLimitBps > 0 {
 		globalLimiter = ratelimit.NewBucketWithRate(float64(globalLimitBps), int64(2*globalLimitBps))
 	}
-
+	
+	rc = newRateCalculator(360, 10*time.Second, &bytesProxied)
+	
 	if statusAddr != "" {
 		go statusService(statusAddr)
 	}
 
-	uri, err := url.Parse(fmt.Sprintf("relay://%s/?id=%s&pingInterval=%s&networkTimeout=%s&sessionLimitBps=%d&globalLimitBps=%d&statusAddr=%s&providedBy=%s", extAddress, id, pingInterval, networkTimeout, sessionLimitBps, globalLimitBps, statusAddr, providedBy))
+	uri, err := url.Parse(fmt.Sprintf("relay://%s/?id=%s&pingInterval=%s&networkTimeout=%s&sessionLimitBps=%d&globalLimitBps=%d&statusAddr=%s&providedBy=%s&averageBps=0&bytesProxied=0", extAddress, id, pingInterval, networkTimeout, sessionLimitBps, globalLimitBps, statusAddr, providedBy))
 	if err != nil {
 		log.Fatalln("Failed to construct URI", err)
 	}

--- a/pool.go
+++ b/pool.go
@@ -5,10 +5,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,6 +19,10 @@ func poolHandler(pool string, uri *url.URL) {
 		log.Println("Joining", pool)
 	}
 	for {
+		values := uri.Query()
+		values.Set("averageBps",fmt.Sprintf("%d",rc.rate(60*60/10)))
+		values.Set("bytesProxied",fmt.Sprintf("%d",atomic.LoadInt64(&bytesProxied)))
+		uri.RawQuery = values.Encode()
 		var b bytes.Buffer
 		json.NewEncoder(&b).Encode(struct {
 			URL string `json:"url"`

--- a/ratecalculator.go
+++ b/ratecalculator.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+var rc *rateCalculator
+
+
+type rateCalculator struct {
+	rates     []int64
+	prev      int64
+	counter   *int64
+	startTime time.Time
+}
+
+func newRateCalculator(keepIntervals int, interval time.Duration, counter *int64) *rateCalculator {
+	r := &rateCalculator{
+		rates:     make([]int64, keepIntervals),
+		counter:   counter,
+		startTime: time.Now(),
+	}
+
+	go r.updateRates(interval)
+
+	return r
+}
+
+func (r *rateCalculator) updateRates(interval time.Duration) {
+	for {
+		now := time.Now()
+		next := now.Truncate(interval).Add(interval)
+		time.Sleep(next.Sub(now))
+
+		cur := atomic.LoadInt64(r.counter)
+		rate := int64(float64(cur-r.prev) / interval.Seconds())
+		copy(r.rates[1:], r.rates)
+		r.rates[0] = rate
+		r.prev = cur
+	}
+}
+
+func (r *rateCalculator) rate(periods int) int64 {
+	var tot int64
+	for i := 0; i < periods; i++ {
+		tot += r.rates[i]
+	}
+	return tot / int64(periods)
+}


### PR DESCRIPTION
open for discussion what info the pool should get and in what units :)

current state has averageBps (same unit as the limits, 60min average) and bytesProxied. Especially the averageBps is important for syncthing in order to not select a relay that is already using all available bandwidth.

https://relays.syncthing.net/endpoint has my testrelay (which is also the info in "providedBy") included

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/syncthing/relaysrv/21)

<!-- Reviewable:end -->
