### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ from the build server. Occasionally, releases will be made available on
 the "Releases" tab of this repository.
 
 See also the README at
-https://github.com/syncthing/syncthing/blob/master/cmd/relaysrv/README.md
+https://github.com/syncthing/syncthing/blob/master/cmd/strelaysrv/README.md
 
 This repository is merely a placeholder for historical reasons. The
 source code is in the [main repository](https://github.com/syncthing/syncthing).


### PR DESCRIPTION
Updated link to Readme from `https://github.com/syncthing/syncthing/blob/master/cmd/relaysrv/README.md`
(404 not found) to `https://github.com/syncthing/syncthing/blob/master/cmd/strelaysrv/README.md`
