### PR TITLE
Point link in README.md to correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ from the build server. Occasionally, releases will be made available on
 the "Releases" tab of this repository.
 
 See also the README at
-https://github.com/syncthing/syncthing/blob/master/cmd/strelaysrv/README.md
+https://github.com/syncthing/syncthing/blob/main/cmd/strelaysrv/README.md
 
 This repository is merely a placeholder for historical reasons. The
 source code is in the [main repository](https://github.com/syncthing/syncthing).


### PR DESCRIPTION
Master is an invalid branch for the documentation and that change is reflected here too https://github.com/syncthing/syncthing/commit/ec718e729e5cc0dbba5c7f2535051b2bf6e5df3a. It auto redirects you from the master branch to the main branch but I figured it should just be changed in the file.


If this is wrong and shouldn't be updated, I apologise.